### PR TITLE
Change the communication style to include community participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Common development utilities for Kinvolk's projects.
 
 We have needs that are consistent across Kinvolk's projects, and thus this
 repository has tools and utilities for making the development of those projects
-easier and more consistent.
+easier and more consistent both by Volks (Kinvolk employees) and as well as
+community participants.
 
 ## Utilities
 
@@ -39,24 +40,24 @@ that. E.g.:
 
 ## Proposing new utilities
 
-We encourage Volks to propose new utilities in this repo. Keep in mind though
-that there is an acceptance criteria:
+We encourage Volks and community participants to propose new utilities in
+this repo. Keep in mind though that there is an acceptance criteria:
 
   * The utility can be used easily and is useful for many developers;
-  * The utility makes something easier or more consistency within a project;
+  * The utility makes something easier or more consistent within a project
+    or projects;
   * The utility has a REAME file or entry in their respective folder's README
     file;
 
-Here are a couple of examples:
+Here are a couple of examples of what should and should not be included:
 
-  * Emacs comman for running a linter: As much as you may find your Emacs's
-    configuration very useful, it is in the end a matter of taste and something
-    individual. So you should rather use a
-    [stash](https://github.com/kinvolk/kinvolk-stash) for that, and **not**
-    `kinvolk-dev-utils`;
+  * Emacs command for running a linter: As much useful as your Emacs's
+    configuration may be, it is in the end a matter of taste and something
+    more personal. So you should rather use a "stash" for that (your own
+    repo of utilities), and **not** Kinvolk's `dev-utils`;
   * Git commit hook running a Go linter: Git is a tool every developer uses,
-    and thus, a hook running a linter that's agreed among the team or the
-    company is something that is useful to have here.
+    and thus, a hook running a linter that's agreed among several proejcts
+    is something that is useful to have here.
 
 For proposing new tools, please open a Pull Request.
 


### PR DESCRIPTION
This repo will be public soon, so we should use a communication style
that includes community participants and not only Volks.