### PR TITLE
README: Add CoC and commit guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Here are a couple of examples of what should and should not be included:
 
 For proposing new tools, please open a Pull Request.
 
+### Commit guidelines
+
+For the general guidelines on making PRs/commits easier to review, please check
+out Kinvolk's
+[contribution guidelines on git](https://github.com/kinvolk/contribution/tree/master/topics/git.md).
+
+## Code of Conduct
+
+Please refer to the Kinvolk
+[Code of Conduct](https://github.com/kinvolk/contribution/blob/master/CODE_OF_CONDUCT.md).
+
 ## License
 
 Kinvolk Dev Utils are licensed under


### PR DESCRIPTION
Kinvolk now has a Contribution repository with a Code of Conduct as well
as PR/commit guidelines, so we mention them in the README.